### PR TITLE
FIX UID and GID for SLURM and munge on front and worker nodes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,5 +17,9 @@ slurm_wn_nodenames: []
 slurm_wn_cpus: 1
 # Default user for ssh and slurm management
 slurm_user: slurm
+slurm_uid: "1994"
 # Password used to derive a munge key for authentication between the server and the workers
 slurm_password: hfe1q4ujaucsu913
+# Default user for munge
+munge_user: munge
+munge_uid: "1995"

--- a/tasks/Debian.yaml
+++ b/tasks/Debian.yaml
@@ -6,7 +6,7 @@
     PKG_FOLDER: "Debian"
   when: ansible_os_family == "Debian"
     
-- name: '[Ubuntu]install slurm dependences in Deb systems'
+- name: '[Ubuntu] install slurm dependences in Deb systems'
   apt: name=libmunge2,libpq5,openssl-blacklist,munge,libmunge-dev,gcc,make,bzip2 update_cache=yes cache_valid_time=3600
 
 - name: '[Ubuntu] Copy required packages'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,8 +27,11 @@
     SLURM_DAEMON: "slurmd"
   when: ansible_os_family == "Debian"
 
-- name: create slurm user and group
-  user: name="{{slurm_user}}" uid="{{slurm_uid}}" shell=/bin/bash system=yes
+- name: create slurm group
+  group: name="{{slurm_user}}" gid="{{slurm_uid}}" system=yes state=present
+
+- name: create slurm user
+  user: name="{{slurm_user}}" uid="{{slurm_uid}}" shell=/bin/bash system=yes group="{{slurm_user}}"
 
 - name: create folders used by SLURM and set slurm owner
   file: path={{item}} state=directory owner=slurm group=slurm

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
   when: ansible_os_family == "Debian"
 
 - name: create slurm user and group
-  user: name="{{slurm_user}}" shell=/bin/bash system=yes
+  user: name="{{slurm_user}}" uid="{{slurm_uid}}" shell=/bin/bash system=yes
 
 - name: create folders used by SLURM and set slurm owner
   file: path={{item}} state=directory owner=slurm group=slurm

--- a/tasks/munge.yaml
+++ b/tasks/munge.yaml
@@ -11,7 +11,7 @@
       yum: name=epel-release
       when: ansible_os_family == "RedHat"
 
-    - name: '[EL] create munge user and group'
+    - name: '[EL] create munge user'
       user:
         name: "{{munge_user}}"
         uid: "{{munge_uid}}"
@@ -25,12 +25,13 @@
       yum: name=munge
       when: ansible_os_family == "RedHat"
 
-    - name: '[Ubuntu] create munge user and group'
+    - name: '[Ubuntu] create munge user'
       user:
         name: "{{munge_user}}"
         uid: "{{munge_uid}}"
         system: yes
         createhome: no
+        shell: '/bin/false'
       when: ansible_os_family == "Debian"
 
     - name: '[Ubuntu] Apt install munge'

--- a/tasks/munge.yaml
+++ b/tasks/munge.yaml
@@ -1,10 +1,17 @@
 ---
-    # install munge
-    - name: Yum install epel
+# install munge
+
+    - name: Set munge group
+      group:
+        name: "{{munge_user}}"
+        gid: "{{munge_uid}}"
+        state: present
+
+    - name: '[EL] Yum install epel'
       yum: name=epel-release
       when: ansible_os_family == "RedHat"
 
-    - name: create munge user and group
+    - name: '[EL] create munge user and group'
       user:
         name: "{{munge_user}}"
         uid: "{{munge_uid}}"
@@ -14,23 +21,34 @@
         shell: '/sbin/nologin'
       when: ansible_os_family == "RedHat"
 
-    - name: create munge user and group
+    - name: '[EL] Yum install munge'
+      yum: name=munge
+      when: ansible_os_family == "RedHat"
+
+    - name: '[Ubuntu] create munge user and group'
       user:
         name: "{{munge_user}}"
         uid: "{{munge_uid}}"
         system: yes
-        shell: '/bin/false'
+        createhome: no
       when: ansible_os_family == "Debian"
 
-    - name: Yum install munge
-      yum: name=munge
-      when: ansible_os_family == "RedHat"
-
-    - name: Apt install munge
+    - name: '[Ubuntu] Apt install munge'
       apt: name=munge update_cache=yes cache_valid_time=3600
       when: ansible_os_family == "Debian"
       ignore_errors: yes
       register: munge_install_result
+
+    - name: "[Ubuntu] Edit munge postinst script to avoid adduser problem"
+      lineinfile:
+        dest: '/var/lib/dpkg/info/munge.postinst'
+        regexp: '      adduser --quiet --system --group --no-create-home munge'
+        line: '      adduser --quiet --system --group --no-create-home munge || true'
+      when: munge_install_result|failed and ansible_os_family == "Debian"
+
+    - name: '[Ubuntu] Fix munge installation'
+      command: apt-get install -f
+      when: munge_install_result|failed and ansible_os_family == "Debian"
 
     - name: Set correct permissions to munge log
       file: path=/var/log/munge mode=0700
@@ -51,12 +69,12 @@
 
         - name: Remove the key
           file: path=/etc/munge/munge.key state=absent
-      when: munge_install_result|failed
+      when: munge_install_result|failed and ansible_os_family == "Debian" and ansible_distribution_version == "16.04"
 
     - shell: echo -n "{{ slurm_password }}" | sha512sum | cut -d' ' -f1 >/etc/munge/munge.key
       when: not munge_key.stat.exists
 
     - name: Set correct permissions to munge.key
-      file: path=/etc/munge/munge.key owner=munge group=munge mode=0400
+      file: path=/etc/munge/munge.key owner="{{munge_user}}" group="{{munge_user}}" mode=0400
 
     - service: name=munge state=restarted

--- a/tasks/munge.yaml
+++ b/tasks/munge.yaml
@@ -5,6 +5,7 @@
       group:
         name: "{{munge_user}}"
         gid: "{{munge_uid}}"
+        system: yes
         state: present
 
     - name: '[EL] Yum install epel'
@@ -19,6 +20,7 @@
         comment: "Runs Uid 'N' Gid Emporium"
         home: '/var/run/munge'
         shell: '/sbin/nologin'
+        group: '{{munge_user}}' 
       when: ansible_os_family == "RedHat"
 
     - name: '[EL] Yum install munge'
@@ -32,6 +34,7 @@
         system: yes
         createhome: no
         shell: '/bin/false'
+        group: '{{munge_user}}'
       when: ansible_os_family == "Debian"
 
     - name: '[Ubuntu] Apt install munge'

--- a/tasks/munge.yaml
+++ b/tasks/munge.yaml
@@ -10,6 +10,17 @@
         uid: "{{munge_uid}}"
         system: yes 
         comment: "Runs Uid 'N' Gid Emporium"
+        home: '/var/run/munge'
+        shell: '/sbin/nologin'
+      when: ansible_os_family == "RedHat"
+
+    - name: create munge user and group
+      user:
+        name: "{{munge_user}}"
+        uid: "{{munge_uid}}"
+        system: yes
+        shell: '/bin/false'
+      when: ansible_os_family == "Debian"
 
     - name: Yum install munge
       yum: name=munge

--- a/tasks/munge.yaml
+++ b/tasks/munge.yaml
@@ -38,18 +38,20 @@
       apt: name=munge update_cache=yes cache_valid_time=3600
       when: ansible_os_family == "Debian"
       ignore_errors: yes
-      register: munge_install_result
+      register: munge_adduser_result
 
     - name: "[Ubuntu] Edit munge postinst script to avoid adduser problem"
       lineinfile:
         dest: '/var/lib/dpkg/info/munge.postinst'
         regexp: '      adduser --quiet --system --group --no-create-home munge'
         line: '      adduser --quiet --system --group --no-create-home munge || true'
-      when: munge_install_result|failed and ansible_os_family == "Debian"
+      when: munge_adduser_result|failed
 
     - name: '[Ubuntu] Fix munge installation'
       command: apt-get install -f
-      when: munge_install_result|failed and ansible_os_family == "Debian"
+      when: munge_adduser_result|failed
+      ignore_errors: yes
+      register: munge_install_result
 
     - name: Set correct permissions to munge log
       file: path=/var/log/munge mode=0700
@@ -70,7 +72,7 @@
 
         - name: Remove the key
           file: path=/etc/munge/munge.key state=absent
-      when: munge_install_result|failed and ansible_os_family == "Debian" and ansible_distribution_version == "16.04"
+      when: munge_install_result|failed
 
     - shell: echo -n "{{ slurm_password }}" | sha512sum | cut -d' ' -f1 >/etc/munge/munge.key
       when: not munge_key.stat.exists

--- a/tasks/munge.yaml
+++ b/tasks/munge.yaml
@@ -10,8 +10,6 @@
         uid: "{{munge_uid}}"
         system: yes 
         comment: "Runs Uid 'N' Gid Emporium"
-        home: '/var/run/munge'
-        shell: '/sbin/nologin'
 
     - name: Yum install munge
       yum: name=munge

--- a/tasks/munge.yaml
+++ b/tasks/munge.yaml
@@ -4,6 +4,15 @@
       yum: name=epel-release
       when: ansible_os_family == "RedHat"
 
+    - name: create munge user and group
+      user:
+        name: "{{munge_user}}"
+        uid: "{{munge_uid}}"
+        system: yes 
+        comment: "Runs Uid 'N' Gid Emporium"
+        home: '/var/run/munge'
+        shell: '/sbin/nologin'
+
     - name: Yum install munge
       yum: name=munge
       when: ansible_os_family == "RedHat"


### PR DESCRIPTION
- munge user and group fixed at 1994
- munge workaroud by editing /var/lib/dpkg/info/munge.postinst to install munge with user previously created
- slurm user and grup fixed at 1995