### PR TITLE
Fixed bug in assignment of hostname and in the creation of slurm.conf

### DIFF
--- a/tasks/front.yaml
+++ b/tasks/front.yaml
@@ -4,7 +4,7 @@
   notify: reload slurm
 
 - hostname:
-    name: slurmserver
+    name: "{{ slurm_server_name }}"
 
 # start SLURM daemon
 - name: Start SLURM service

--- a/tasks/wn.yaml
+++ b/tasks/wn.yaml
@@ -6,6 +6,7 @@
 - name: Create the slurm.conf file
   template: dest={{ SLURM_CONF }} src=slurm.conf.j2
   notify: reload slurm
+  when: inventory_hostname != slurm_server_name 
 
 # start SLURM daemon
 - name: Start Slurm Daemon


### PR DESCRIPTION
Fixed a bug in the setup of the front node, where hostname was assigned to 'slurmserver' instead of the value passed in the variable slurm_server_name. Also, the slurm.conf file was written during worker node setup regardless of the worker also being the head node, which would cause the slurmctld daemon to fail to operate correctly.